### PR TITLE
feat: add ability to create insecure connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ multihash = "0.16.3"
 parking_lot = "0.12.1"
 quinn = "0.9.0"
 rcgen = "0.10.0"
-rustls = "0.20.7"
+# "dangerous_configuration" feature allows for configuring insecure quic endpoints
+rustls = { version = "0.20.7", features = ["dangerous_configuration"] }
 serde = "1.0.147"
 tokio = { version = "1.21.2", features = ["full"] }
 tokio-serde = { version = "0.8.0", features = ["bincode"] }


### PR DESCRIPTION
The insecure connections are primarily being used while measuring krakensync in `testgrounds` 